### PR TITLE
Supported Domains to be kept

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,8 @@ gpg -k
 Supported Domains:
 
 - DCC
-- DDCC
-- DIVOC
-- ICAO
-- SHC
-- CRED
-- RACSEL-DDVC
 - IPS-PILGRIMAGE
+- PH4H
 
 ## Adding a new trust domain
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Supported Domains:
 
 - DCC
 - IPS-PILGRIMAGE
+- DICVP
 - PH4H
 
 ## Adding a new trust domain
@@ -59,7 +60,7 @@ New trust domains can be established only in agreement between the requesting pa
 Collaborate with the WHO's secretariat to gather comprehensive insights and feedback for the development of the new trust domain.
 
 Once the new trust domain is established create new subdirectory in 'onboarding' subdir that reflect the agreed domain name.
-If you are already onboarded for a domain (e.g. DCC, RACSEL-DDVC etc.) you only need to provide SCA for the the newly added domain.  This can either be an existing SCA or a new SCA.
+If you are already onboarded for a domain (e.g. DCC, IPS-PILGRIMAGE,DICVP,PH4H etc.) you only need to provide SCA for the the newly added domain.  This can either be an existing SCA or a new SCA.
 If the newly added domain is the first one for this participant, UPLOAD, TLS and SCA must be generated.
 
 # Trusted Issuer

--- a/scripts/tests/folder_mandatory_files.py
+++ b/scripts/tests/folder_mandatory_files.py
@@ -14,7 +14,7 @@ def test_folder_mandatory_files(country_folder):
 
     # Testing folder structure
     for domain in ofiles.keys():
-        assert domain in ('DCC','DDCC','DIVOC','ICAO','SHC','CRED','RACSEL-DDVC','IPS-PILGRIMAGE','dICVP'), 'Invalid domain: '+domain
+        assert domain in ('DCC','IPS-PILGRIMAGE','dICVP','PH4H'), 'Invalid domain: '+domain
 
         # Check if certificates are present in the current domain
         if ('TLS', 'TLS.pem') in ofiles[domain]:

--- a/scripts/tests/groups_domains.py
+++ b/scripts/tests/groups_domains.py
@@ -10,4 +10,4 @@ def test_valid_domain(cert):
 
     domain = cert.pathinfo.get('domain')
     assert domain, 'Certificate at incorrect location'
-    assert domain.upper() in ('DCC','DDCC','DIVOC','ICAO','SHC','CRED','RACSEL-DDVC','IPS-PILGRIMAGE','dICVP'), 'Invalid domain: ' + domain
+    assert domain.upper() in ('DCC','IPS-PILGRIMAGE','PH4H'), 'Invalid domain: ' + domain

--- a/scripts/tests/groups_domains.py
+++ b/scripts/tests/groups_domains.py
@@ -10,4 +10,4 @@ def test_valid_domain(cert):
 
     domain = cert.pathinfo.get('domain')
     assert domain, 'Certificate at incorrect location'
-    assert domain.upper() in ('DCC','IPS-PILGRIMAGE','PH4H'), 'Invalid domain: ' + domain
+    assert domain.upper() in ('DCC','IPS-PILGRIMAGE','dICVP','PH4H'), 'Invalid domain: ' + domain


### PR DESCRIPTION
Supported Domains to be kept: DCC, IPS-PILGRIMAGE,DICVP PH4H as per JIRA DDCCGW-723 , other domains will be cleaned up.

Updated below files:
 - tng-participant-template/scripts/tests/groups_domains.py file 
 - tng-participant-template/scripts/tests/scripts/tests/folder_mandatory_files.py
 - Readme.md
